### PR TITLE
Added exists method

### DIFF
--- a/android/src/main/java/com/taluttasgiran/rnsecurestorage/RNKeyStore.java
+++ b/android/src/main/java/com/taluttasgiran/rnsecurestorage/RNKeyStore.java
@@ -145,6 +145,10 @@ public class RNKeyStore {
         return new String(decryptAesCipherText(secretKey, cipherTextBytes), "UTF-8");
     }
 
+    public boolean exists(Context context, String alias) throws IOException {
+        return Storage.exists(context, Constants.SKS_DATA_FILENAME + alias);
+    }
+
 
     private String getKeyStore() {
         try {

--- a/android/src/main/java/com/taluttasgiran/rnsecurestorage/RNSecureStorageModule.java
+++ b/android/src/main/java/com/taluttasgiran/rnsecurestorage/RNSecureStorageModule.java
@@ -74,6 +74,22 @@ public class RNSecureStorageModule extends ReactContextBaseJavaModule {
         }
     }
 
+    @ReactMethod
+    public void exists(String key, Promise promise) {
+        if (useKeystore()) {
+            try {
+                promise.resolve(rnKeyStore.exists(getReactApplicationContext(), key));
+            } catch (Exception e) {
+                promise.reject(e);
+            }
+        } else {
+            try {
+                promise.resolve(prefs.contains(key));
+            } catch (IllegalViewOperationException e) {
+                promise.reject(e);
+            }
+        }
+    }
 
     @ReactMethod
     public void remove(String key, Promise promise) {

--- a/android/src/main/java/com/taluttasgiran/rnsecurestorage/Storage.java
+++ b/android/src/main/java/com/taluttasgiran/rnsecurestorage/Storage.java
@@ -3,6 +3,7 @@ package com.taluttasgiran.rnsecurestorage;
 import android.content.Context;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -25,6 +26,11 @@ public final class Storage {
             bytesRead = fis.read(buffer);
         }
         return baos.toByteArray();
+    }
+
+    public static boolean exists(Context context, String filename) throws IOException {
+        File file = context.getFileStreamPath(filename);
+        return file != null && file.exists();
     }
 
     public static void resetValues(Context context, String[] filenames) {

--- a/ios/RNSecureStorage.m
+++ b/ios/RNSecureStorage.m
@@ -51,6 +51,27 @@ RCT_EXPORT_MODULE()
     return value;
 }
 
+- (BOOL)searchKeychainCopyMatchingExists:(NSString *)identifier {
+    NSMutableDictionary *searchDictionary = [self newSearchDictionary:identifier];
+    
+    // Add search attributes
+    [searchDictionary setObject:(id)kSecMatchLimitOne forKey:(id)kSecMatchLimit];
+    
+    // Add search return types
+    [searchDictionary setObject:(id)kCFBooleanTrue forKey:(id)kSecReturnData];
+    
+    NSDictionary *found = nil;
+    CFTypeRef result = NULL;
+    OSStatus status = SecItemCopyMatching((CFDictionaryRef)searchDictionary,
+                                          (CFTypeRef *)&result);
+    
+    found = (__bridge NSDictionary*)(result);
+    if (found) {
+      return YES;
+    }
+    return NO;
+}
+
 - (BOOL)createKeychainValue:(NSString *)value forIdentifier:(NSString *)identifier options: (NSDictionary * __nullable)options {
     CFStringRef accessible = accessibleValue(options);
     NSMutableDictionary *dictionary = [self newSearchDictionary:identifier];
@@ -164,6 +185,24 @@ RCT_EXPORT_METHOD(get:(NSString *)key
     @catch (NSException *exception) {
         NSString* errorMessage = @"key does not present";
         reject(@"1", errorMessage, secureKeyStoreError(errorMessage));
+    }
+}
+
+RCT_EXPORT_METHOD(exists:(NSString *)key
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    @try {
+      [self handleAppUninstallation];
+      BOOL exists = [self searchKeychainCopyMatchingExists:key];
+      if (exists) {
+        resolve(@true);
+      } else {
+        resolve(@false);
+      }
+    }
+    @catch(NSException *exception) {
+      resolve(@false);
     }
 }
 

--- a/ios/RNSecureStorage.m
+++ b/ios/RNSecureStorage.m
@@ -60,13 +60,11 @@ RCT_EXPORT_MODULE()
     // Add search return types
     [searchDictionary setObject:(id)kCFBooleanTrue forKey:(id)kSecReturnData];
     
-    NSDictionary *found = nil;
     CFTypeRef result = NULL;
     OSStatus status = SecItemCopyMatching((CFDictionaryRef)searchDictionary,
                                           (CFTypeRef *)&result);
     
-    found = (__bridge NSDictionary*)(result);
-    if (found) {
+    if (status != errSecItemNotFound) {
       return YES;
     }
     return NO;

--- a/typescript/rn-secure-storage.d.ts
+++ b/typescript/rn-secure-storage.d.ts
@@ -66,6 +66,10 @@ declare module "rn-secure-storage" {
      */
     get(key: string): Promise<string | null>;
     /**
+     * Checks if a key has been set.
+     */
+    exists(key: string): Promise<boolean | null>;
+    /**
      * Set a value from secure storage.
      */
     set(


### PR DESCRIPTION
This PR adds a way to check the Keystore & Keychain to determine if a key exists, if it does it returns true, otherwise it will return false. For Android, it will use either the Keystore or preferences depending on what `useKeystore()` returns and check to see if the key exists. For iOS, it will search the Keychain and see if an item was found or not based upon the status of the search.