### PR TITLE
fixing the secure storage issue on arabic devices

### DIFF
--- a/android/src/main/java/com/taluttasgiran/rnsecurestorage/RNSecureStorageModule.java
+++ b/android/src/main/java/com/taluttasgiran/rnsecurestorage/RNSecureStorageModule.java
@@ -14,6 +14,7 @@ import com.securepreferences.SecurePreferences;
 
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
+import java.util.Locale;
 
 public class RNSecureStorageModule extends ReactContextBaseJavaModule {
     private SharedPreferences prefs;
@@ -36,8 +37,12 @@ public class RNSecureStorageModule extends ReactContextBaseJavaModule {
     public void set(String key, String value, @Nullable ReadableMap options, Promise promise) {
         if (useKeystore()) {
             try {
+                Locale initialLocale = Locale.getDefault();
+                Locale.setDefault(Locale.ENGLISH);
                 rnKeyStore.setCipherText(getReactApplicationContext(), key, value);
                 promise.resolve("RNSecureStorage: Key stored/updated successfully");
+                // Reset default locale
+                Locale.setDefault(initialLocale);
             } catch (Exception e) {
                 promise.reject(e);
             }


### PR DESCRIPTION
Hey Talut, This is a fix for the know issue of setting a secure storage key on arabic or persian locale devices

i set the locale to EN the revert it back