### PR TITLE
Removed 'buildToolsVersion' line

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.2"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Removed buildToolsVersion line as recommended by Gradle:

"WARNING: The specified Android SDK Build Tools version (28.0.2) is ignored, as it is below the minimum supported version (28.0.3) for Android Gradle Plugin 3.4.2.
Android SDK Build Tools 28.0.3 will be used.
To suppress this warning, remove "buildToolsVersion '28.0.2'" from your build.gradle file, as each version of the Android Gradle Plugin now has a default version of the build tools."