### PR TITLE
Fix android gradle minSdkVersion for react-native 0.64 #61

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,6 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
 
 buildscript {
     // The Android Gradle plugin is only required when opening the android folder stand-alone.
@@ -18,10 +21,10 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
         versionCode 4
         versionName "2.0.7"
     }


### PR DESCRIPTION
Fix android build fails for AndroidTest with minSdkVersion 17 with react-native 0.64 ( #61)