### PR TITLE
Update deprecated 'compile' call in gradle.build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,6 +41,6 @@ dependencies {
     implementation "com.facebook.react:react-native:+"
 }
 task copyDownloadableDepsToLibs(type: Copy) {
-    from configurations.compile
+    from configurations.implementation
     into 'libs'
 }


### PR DESCRIPTION
Utilize 'implementation' vice 'compile' in gradle.build so the Gradle build won't fail.