### PR TITLE
Cleanup biometry declaration

### DIFF
--- a/ios/RNSecureStorage.m
+++ b/ios/RNSecureStorage.m
@@ -48,12 +48,6 @@ RCT_EXTERN_METHOD(multiRemove:(NSArray *)keys resolver:(RCTPromiseResolveBlock)r
 */
 RCT_EXTERN_METHOD(clear:(RCTPromiseResolveBlock *)resolver rejecter:(RCTPromiseRejectBlock)reject)
 
-/**
-  Get supported biometry type
-*/
-RCT_EXTERN_METHOD(getSupportedBiometryType: (RCTPromiseResolveBlock *)resolver rejecter:(RCTPromiseRejectBlock *)reject)
-
-
 + (BOOL)requiresMainQueueSetup
 {
     return YES;


### PR DESCRIPTION
The current version crashes because of the missing implementation for biometry.
I found that biometry was removed in commit 3bf90b43 including its demonstration in the sample project. But the declaration was left in `RNSecureStorage.m` 
After this cleanup, the framework works without the crash