### PR TITLE
include OSStatus in error message when error occurs during key storage on iOS

### DIFF
--- a/ios/RNSecureStorage.swift
+++ b/ios/RNSecureStorage.swift
@@ -19,10 +19,11 @@ class RNSecureStorage: NSObject {
     func setItem(_ key:String, value:String, options:[String:Any], resolver: RCTPromiseResolveBlock, rejecter: RCTPromiseRejectBlock){
         let accessible = options["accessible"] as! String
         let status = helper.createKeychainValue(key: key, value: value, accessible: accessible)
-        if status {
+        if status == errSecSuccess {
             resolver("Key stored successfully")
-        }else{
-            rejecter("KEY_NOT_STORED","RNSecureStorage: An error occurred during key storage", RNSecureErrors.KEY_NOT_STORED)
+        } else {
+            let errorMessage = "RNSecureStorage: An error occurred during key storage. OSStatus: \(status)"
+            rejecter("KEY_NOT_STORED", errorMessage, RNSecureErrors.KEY_NOT_STORED)
         }
     }
     

--- a/ios/RNSecureStorageHelper.swift
+++ b/ios/RNSecureStorageHelper.swift
@@ -8,7 +8,7 @@ class RNSecureStorageHelper {
     /*
      Store an item in keychain.
      */
-    func createKeychainValue(key: String, value: String, accessible:String) -> Bool {
+    func createKeychainValue(key: String, value: String, accessible:String) -> OSStatus {
         let keyData = appBundleName+"."+key
         let tag = keyData.data(using: .utf8)!
         let valData =  value.data(using: .utf8)
@@ -21,10 +21,7 @@ class RNSecureStorageHelper {
         
         SecItemDelete(query as CFDictionary)
         
-        let status = SecItemAdd(query as CFDictionary, nil)
-        
-        return status == errSecSuccess
-        
+        return SecItemAdd(query as CFDictionary, nil)
     }
     
     /*
@@ -109,7 +106,7 @@ class RNSecureStorageHelper {
         var settedPairs = 0
         for (key, value) in keyValuePairs {
             let val = self.createKeychainValue(key: key, value: value, accessible: accessible)
-            if val {
+            if val == errSecSuccess {
                 settedPairs += 1
             }
         }


### PR DESCRIPTION
My team has been having some problems with a hard-to-reproduce issue that seems to be occurring when items are saved to the keychain. We are able to see in the logs that the error occurred during key storage, but not able to get any more details as to the reason for the error during key storage. I thought I'd just give it a shot here and include the error code in the error message.

I've never done any swift development and don't have a working development environment for this, so I just based my edits on what I could read in the documentation. Feel free to double check if my edits make sense since I'm not able to run the swift code myself :smile: 